### PR TITLE
Update drillresults.py

### DIFF
--- a/src/windows/tools/drillresults.py
+++ b/src/windows/tools/drillresults.py
@@ -412,8 +412,10 @@ def checkreport(reportfile, crasherfile, crash_hash):
 
 
 #    pc_module = pc_in_mapped_address(reporttext, instraddr)
-    crashid['exceptions'][exceptionnum]['pcmodule'] = pc_in_mapped_address(reporttext, instraddr)
-
+    try:
+        crashid['exceptions'][exceptionnum]['pcmodule'] = pc_in_mapped_address(reporttext, instraddr)
+    except:
+        print reporttext 
     # Get the cdb line that contains the crashing instruction
     instructionline = getinstr(reporttext, instraddr)
     crashid['exceptions'][exceptionnum]['instructionline'] = instructionline


### PR DESCRIPTION
I found a small bug in drillresults.py which will cause it to crash if certain crash reports are read. (See Issue #2 )

I've implemented a small "Try / Except" patch which will allow the script to continue on and which will print out the offending crash report so it can be removed manually. 
