### PR TITLE
_execute_child argument added

### DIFF
--- a/src/certfuzz/runners/killableprocess.py
+++ b/src/certfuzz/runners/killableprocess.py
@@ -90,7 +90,7 @@ class Popen(subprocess.Popen):
     if mswindows:
         def _execute_child(self, args, executable, preexec_fn, close_fds,
                            cwd, env, universal_newlines, startupinfo,
-                           creationflags, shell,
+                           creationflags, shell, to_close,
                            p2cread, p2cwrite,
                            c2pread, c2pwrite,
                            errread, errwrite):


### PR DESCRIPTION
When I was setting CERTFUZZ, some Popen error about given argument count occured again and again.
This code was tested on Win7x86, Win10x64 only.
