### PR TITLE
Additional config options to copy fuzzed file into a static file and execute custom postprocess

### DIFF
--- a/src/certfuzz/iteration/iteration_base.py
+++ b/src/certfuzz/iteration/iteration_base.py
@@ -172,6 +172,19 @@ class IterationBase(object):
         fuzzed_file = self.fuzzer.output_file_path
         workingdir_base = self.working_dir
         self.cmd_template = self.cfg['target']['cmdline_template']
+
+        if 'copyseedto' in self.cfg['target']:
+            from shutil import copyfile
+            copyseedto = str(self.cfg['target'].get('copyseedto', ''))
+            logger.debug("Copying seed to " + copyseedto)
+            copyfile(fuzzed_file, copyseedto)
+
+        if 'postprocessseed' in self.cfg['target']:
+            import os
+            postprocessseed = str(self.cfg['target']['postprocessseed'])
+            logger.debug("Executing postprocess " + postprocessseed)
+            os.system(postprocessseed)
+
         self.runner = self.runner_cls(
             self._runner_options, self.cmd_template, fuzzed_file, workingdir_base)
 

--- a/src/certfuzz/minimizer/minimizer_base.py
+++ b/src/certfuzz/minimizer/minimizer_base.py
@@ -187,6 +187,17 @@ class Minimizer(object):
         self.tempfile = f.name
         filetools.copy_file(self.testcase.fuzzedfile.path, self.tempfile)
 
+        if 'copyseedto' in self.cfg['target']:
+            copyseedto = str(self.cfg['target'].get('copyseedto', ''))
+            logger.debug("Copying seed to " + copyseedto)
+            filetools.copy_file(self.testcase.fuzzedfile.path, copyseedto)
+
+        if 'postprocessseed' in self.cfg['target']:
+            import os
+            postprocessseed = str(self.cfg['target']['postprocessseed'])
+            logger.debug("Executing postprocess " + postprocessseed)
+            os.system(postprocessseed)
+
         # figure out what testcase signatures belong to this fuzzedfile
         self.debugger_timeout = self.cfg['debugger']['runtimeout']
         self.crash_hashes = []
@@ -462,6 +473,17 @@ class Minimizer(object):
             self._raise('Outfile should not already exist: %s' % outfile)
         self.logger.debug('\tCopying %s to %s', self.tempfile, outfile)
         filetools.copy_file(self.tempfile, outfile)
+
+        if 'copyseedto' in self.cfg['target']:
+            copyseedto = str(self.cfg['target'].get('copyseedto', ''))
+            logger.debug("Copying seed to " + copyseedto)
+            filetools.copy_file(self.tempfile, copyseedto)
+
+        if 'postprocessseed' in self.cfg['target']:
+            import os
+            postprocessseed = str(self.cfg['target']['postprocessseed'])
+            logger.debug("Executing postprocess " + postprocessseed)
+            os.system(postprocessseed)
 
         new_testcase.fuzzedfile = BasicFile(outfile)
         self.logger.debug('\tNew fuzzed_content file: %s %s',

--- a/src/certfuzz/minimizer/win_minimizer.py
+++ b/src/certfuzz/minimizer/win_minimizer.py
@@ -130,3 +130,14 @@ class WindowsMinimizer(MinimizerBase):
             self._writezip()
         else:
             write_file(''.join(self.newfuzzed), self.tempfile)
+
+            if 'copyseedto' in self.cfg['target']:
+                copyseedto = str(self.cfg['target'].get('copyseedto', ''))
+                logger.debug("Copying seed to " + copyseedto)
+                write_file(''.join(self.newfuzzed), copyseedto)
+
+            if 'postprocessseed' in self.cfg['target']:
+                import os
+                postprocessseed = str(self.cfg['target']['postprocessseed'])
+                logger.debug("Executing postprocess " + postprocessseed)
+                os.system(postprocessseed)

--- a/src/windows/configs/examples/bff.yaml
+++ b/src/windows/configs/examples/bff.yaml
@@ -34,6 +34,8 @@ campaign:
 target:
     program: C:\BFF\imagemagick\convert.exe
     cmdline_template: $PROGRAM $SEEDFILE NUL
+    #copyseedto: C:\BFF\current.seed
+    #postprocessseed: C:\BFF\postprocess.exe C:\BFF\current.seed
     
     # With the default ImageMagick fuzz run, the above target options
     # will result in the following invocation of ImageMagick:


### PR DESCRIPTION
Some applications don't take input file as a command line param, instead it will look for a hardcoded path. Using this PR you can specify that path and let BFF to copy fuzzed file into that, so your application can pick it up
New options proposed:
copyseedto - make a copy of the current fuzzed file
postprocessseed - execute custom program to postprocess the current fuzzed file
There was a demand to such feature. This PR is based on a patch proposed here: https://github.com/CERTCC/certfuzz/issues/16

I'm open for discussion to enhance this PR